### PR TITLE
make string size mandatory

### DIFF
--- a/it.univaq.disim.typhonml.parent/bundles/it.univaq.disim.typhonml.xtext/src/it/univaq/disim/typhon/TyphonML.xtext
+++ b/it.univaq.disim.typhonml.parent/bundles/it.univaq.disim.typhonml.xtext/src/it/univaq/disim/typhon/TyphonML.xtext
@@ -61,7 +61,7 @@ BigintType returns BigintType:
 
 StringType returns StringType:
 	{StringType}
-	'string' ('[' maxSize=EInt ']')?
+	'string' '[' maxSize=EInt ']'
 	;
 
 TextType returns TextType:


### PR DESCRIPTION
Since not giving a string size leads to errors when using QL, I propose making it mandatory (suggested by @DavyLandman)